### PR TITLE
update download links to Hugging Face datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ You can download the full dataset behind [paperswithcode.com](https://paperswith
 
 Download links for the data dumps are:
 
-- [All papers with abstracts](https://production-media.paperswithcode.com/about/papers-with-abstracts.json.gz)
-- [Links between papers and code](https://production-media.paperswithcode.com/about/links-between-papers-and-code.json.gz)
-- [Evaluation tables](https://production-media.paperswithcode.com/about/evaluation-tables.json.gz)
-- [Methods](https://production-media.paperswithcode.com/about/methods.json.gz)
-- [Datasets](https://production-media.paperswithcode.com/about/datasets.json.gz)
+- [All papers with abstracts](https://huggingface.co/datasets/pwc-archive/papers-with-abstracts)
+- [Links between papers and code](https://huggingface.co/datasets/pwc-archive/links-between-paper-and-code)
+- [Evaluation tables](https://huggingface.co/datasets/pwc-archive/evaluation-tables)
+- [Methods](https://huggingface.co/datasets/pwc-archive/methods)
+- [Datasets](https://huggingface.co/datasets/pwc-archive/datasets)
 
 The last JSON is in the [sota-extractor](https://github.com/paperswithcode/sota-extractor) format and the code
 from there can be used to load in the JSON into a set of Python classes. 


### PR DESCRIPTION
I noticed that the links to the different resources doesn't work anymore. This would update them to use the archive datasets on Hugging Face so users can still use the data 🤗

see PWC Archive Org on Hugging Face: https://huggingface.co/pwc-archive